### PR TITLE
Grammar improvements

### DIFF
--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -52,9 +52,9 @@ pub fn connect(
         public_key = row.get(0);
         token = row.get(1);
     } else {
-        println!("To securely connect, we need some data from the server (\"public key\").");
-        println!("The server owner should have given you this.");
-        println!("Once you have it, enter it here:");
+        println!("To securely connect, data from the server (\"public key\") is needed.");
+        println!("You can obtain the \"public key\" from the server owner.");
+        println!("Enter the key here:");
         public_key = readline!({ return None; });
 
         db.execute(
@@ -124,7 +124,7 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                 id = Some(login.id);
                 if login.created {
                     println!("Tried to log in with your token: Apparently an account was created.");
-                    println!("I think you should stay away from this server. It's weird.");
+                    println!("I think you should stay away from this server. Something is not quite right.");
                     return None;
                 }
                 println!("Logged in as user #{}", login.id);
@@ -133,7 +133,7 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                 common::ERR_LOGIN_INVALID |
                 common::ERR_MISSING_FIELD => {},
                 common::ERR_LOGIN_BANNED => {
-                    println!("Oh noes, you have been banned from this server :(");
+                    println!("You have been banned from this server. :(");
                     return None;
                 },
                 common::ERR_LOGIN_BOT => {
@@ -149,12 +149,12 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                     return None;
                 },
                 _ => {
-                    println!("The server responded with an invalid error :/");
+                    println!("The server responded with an invalid error.");
                     return None;
                 }
             },
             Ok(_) => {
-                println!("The server responded with an invalid packet :/");
+                println!("The server responded with an invalid packet.");
                 return None;
             }
             Err(err) => {
@@ -202,7 +202,7 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                     return None;
                 },
                 common::ERR_LOGIN_BANNED => {
-                    println!("Oh noes, you have been banned from this server :(");
+                    println!("You have been banned from this server. :(");
                     return None;
                 },
                 common::ERR_LOGIN_BOT => {
@@ -214,12 +214,12 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                     return None;
                 },
                 _ => {
-                    println!("The server responded with an invalid error :/");
+                    println!("The server responded with an invalid error.");
                     return None;
                 }
             },
             Ok(_) => {
-                println!("The server responded with an invalid packet :/");
+                println!("The server responded with an invalid packet.");
                 return None;
             }
             Err(err) => {

--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -124,7 +124,7 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                 id = Some(login.id);
                 if login.created {
                     println!("Tried to log in with your token: Apparently an account was created.");
-                    println!("I think you should stay away from this server. It's wierd.");
+                    println!("I think you should stay away from this server. It's weird.");
                     return None;
                 }
                 println!("Logged in as user #{}", login.id);

--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -124,7 +124,7 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                 id = Some(login.id);
                 if login.created {
                     println!("Tried to log in with your token: Apparently an account was created.");
-                    println!("I think you should stay away from this server. Something is not quite right.");
+                    println!("I think you should stay away from this server. It's wierd.");
                     return None;
                 }
                 println!("Logged in as user #{}", login.id);
@@ -214,12 +214,12 @@ config.danger_connect_without_providing_domain_for_certificate_verification_and_
                     return None;
                 },
                 _ => {
-                    println!("The server responded with an invalid error.");
+                    println!("The server responded with an invalid error. :/");
                     return None;
                 }
             },
             Ok(_) => {
-                println!("The server responded with an invalid packet.");
+                println!("The server responded with an invalid packet. :/");
                 return None;
             }
             Err(err) => {

--- a/client/src/frontend_minimal.rs
+++ b/client/src/frontend_minimal.rs
@@ -192,7 +192,7 @@ impl Screen {
             };
             if let Some(attribute) = session.attributes.get(&id) {
                 if attribute.pos == 0 {
-                    println!("Can't assign that attribute");
+                    println!("Unable to assign that attribute");
                     continue;
                 }
                 if add {
@@ -207,7 +207,7 @@ impl Screen {
                     // TODO remove_item once stable
                 }
             } else {
-                println!("Couldn't find attribute");
+                println!("Could not find attribute");
             }
         }
         Ok(attributes)

--- a/client/src/listener.rs
+++ b/client/src/listener.rs
@@ -126,10 +126,10 @@ pub fn listen(
                                     println!("Invalid credentials");
                                 },
                                 Ok(Packet::Err(common::ERR_UNKNOWN_CHANNEL)) => {
-                                    println!("It appears this channel was deleted");
+                                    println!("This channel was deleted");
                                 },
                                 Ok(Packet::Err(common::ERR_UNKNOWN_ATTRIBUTE)) => {
-                                    println!("It appears this attribute was deleted");
+                                    println!("This attribute was deleted");
                                 },
                                 Ok(Packet::Err(common::ERR_LIMIT_REACHED)) => {
                                     println!("Too short or too long. No idea which");
@@ -141,7 +141,7 @@ pub fn listen(
                                     println!("Invalid attribute position");
                                 },
                                 Ok(Packet::Err(common::ERR_ATTR_LOCKED_NAME)) => {
-                                    println!("Can't change the name of that attribute");
+                                    println!("Can not change the name of that attribute");
                                 },
                                 Ok(_) => {
                                     unimplemented!();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -229,7 +229,7 @@ fn main() {
                     usage!(1, "connect <ip[:port]>");
                     let mut session = session.lock().unwrap();
                     if session.is_some() {
-                        println!("Please disconnect first");
+                        println!("You have to disconnect before doing that.");
                         continue;
                     }
                     *session = connect::connect(&db.lock().unwrap(), &args[0], &nick, &screen, &ssl);
@@ -248,7 +248,7 @@ fn main() {
                     let addr = match parse_ip(&args[0]) {
                         Some(some) => some,
                         None => {
-                            println!("Not a valid IP");
+                            println!("Invalid IP");
                             continue;
                         }
                     };
@@ -286,7 +286,7 @@ fn main() {
                                 unassignable: false
                             })
                         },
-                        _ => { println!("Can't create that"); continue; }
+                        _ => { println!("Unable to create that"); continue; }
                     };
                     if let Err(err) = common::write(&mut session.stream, &packet) {
                         println!("Failed to send packet");
@@ -381,17 +381,17 @@ fn main() {
                             }))
                         } else { None },
                         _ => {
-                            println!("Can't delete that");
+                            println!("Unable to delete that");
                             continue;
                         }
                     };
                     if let Some(packet) = packet {
                         if let Err(err) = common::write(&mut session.stream, &packet) {
-                            println!("Oh no could not delete");
+                            println!("Unable to delete");
                             println!("{}", err);
                         }
                     } else {
-                        println!("Nothing with that ID");
+                        println!("Nothing with that ID exists");
                     }
                 },
                 "delete" => {
@@ -423,17 +423,17 @@ fn main() {
                                 id: id
                             })),
                         _ => {
-                            println!("Can't delete that");
+                            println!("Unable to delete that");
                             continue;
                         }
                     };
                     if let Some(packet) = packet {
                         if let Err(err) = common::write(&mut session.stream, &packet) {
-                            println!("Oh no could not delete");
+                            println!("Unable to delete");
                             println!("{}", err);
                         }
                     } else {
-                        println!("Nothing with that ID");
+                        println!("Nothing with that ID exists");
                     }
                 },
                 "list" => {
@@ -487,7 +487,7 @@ fn main() {
                             }
                             println!("{}", result);
                         },
-                        _ => println!("Can't list that")
+                        _ => println!("Unable to list that")
                     }
                 },
                 "info" => {
@@ -585,7 +585,7 @@ fn main() {
 
         match *session.lock().unwrap() {
             None => {
-                println!("You're not connected to a server");
+                println!("You are not connected to a server");
                 continue;
             },
             Some(ref mut session) => {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -720,6 +720,6 @@ fn parse_ip(input: &str) -> Option<SocketAddr> {
     use std::net::ToSocketAddrs;
     match (ip, port).to_socket_addrs() {
         Ok(mut ok) => ok.next(),
-        Err(_) => { eprintln!(":("); None }
+        Err(_) => { println!(":("); None }
     }
 }


### PR DESCRIPTION
I'm unsure if you like it this way, but it's just me requesting an improvement. ¯\\\_(ツ)_/¯

- Grammar improvements
- Use println > eprintln in the client

¯\\\_(ツ)_/¯